### PR TITLE
Bump to latest qr and include tslib in all deps

### DIFF
--- a/packages/attestations-common/CHANGELOG.md
+++ b/packages/attestations-common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.1
+
+**Bug fixes**:
+
+- Include tslib in dependencies
+
 ## 1.0.0
 
 - Initial release

--- a/packages/attestations-common/package.json
+++ b/packages/attestations-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/attestations-common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "module": "dist/attestations-common.esm.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,8 @@
     "ethereumjs-util": "^6.2.0",
     "ethereumjs-wallet": "^0.6.3",
     "js-sha3": "^0.8.0",
-    "randombytes": "^2.1.0"
+    "randombytes": "^2.1.0",
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@bloomprotocol/eslint-config": "^1.0.0-beta.1",
@@ -44,7 +45,6 @@
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
     "tsdx": "^0.12.1",
-    "tslib": "^1.10.0",
     "typescript": "^3.7.4"
   },
   "jest": {

--- a/packages/share-kit-react/CHANGELOG.md
+++ b/packages/share-kit-react/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.5.1
+
+**Bug fixes**:
+
+- Include tslib in dependencies
+
+**Miscellaneous**:
+
+- Bump to latest `@bloomprotocol/qr`
+
 ## 4.5.0
 
 **Improvements**

--- a/packages/share-kit-react/package.json
+++ b/packages/share-kit-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/share-kit-react",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "React wrapper for @bloomprotocol/share-kit",
   "main": "dist/index.js",
   "module": "dist/share-kit.esm.js",
@@ -22,8 +22,9 @@
     "storybook": "start-storybook -p 9001"
   },
   "dependencies": {
-    "@bloomprotocol/share-kit": "7.6.0",
-    "react-forward-props": "^1.1.2"
+    "@bloomprotocol/share-kit": "7.6.1",
+    "react-forward-props": "^1.1.2",
+    "tslib": "^1.10.0"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0"
@@ -53,7 +54,6 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "tsdx": "^0.12.1",
-    "tslib": "^1.10.0",
     "typescript": "^3.7.4",
     "webpack": "^4.41.5"
   },

--- a/packages/share-kit-reactnative/CHANGELOG.md
+++ b/packages/share-kit-reactnative/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.1
+
+**Bug fixes**:
+
+- Include tslib in dependencies
+
 ## 1.1.0
 
 **Improvements**

--- a/packages/share-kit-reactnative/package.json
+++ b/packages/share-kit-reactnative/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/share-kit-reactnative",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React Native implementation of @bloomprotocol/share-kit",
   "main": "dist/index.js",
   "module": "dist/share-kit-reactnative.esm.js",
@@ -33,6 +33,7 @@
     "extend": "^3.0.2",
     "react-native-linear-gradient": "^2.5.6",
     "react-native-svg": "^9.6.1",
+    "tslib": "^1.10.0",
     "url": "^0.11.0"
   },
   "peerDependencies": {
@@ -56,7 +57,6 @@
     "react-native-typescript-transformer": "^1.2.12",
     "rimraf": "^2.6.2",
     "tsdx": "^0.12.1",
-    "tslib": "^1.10.0",
     "typescript": "^3.7.4"
   },
   "publishConfig": {

--- a/packages/share-kit/CHANGELOG.md
+++ b/packages/share-kit/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 7.6.1
+
+**Bug fixes**:
+
+- Include tslib in dependencies
+
+**Miscellaneous**:
+
+- Bump to latest `@bloomprotocol/qr`
+
 ## 7.6.0
 
 **Improvements**

--- a/packages/share-kit/package-lock.json
+++ b/packages/share-kit/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bloomprotocol/share-kit",
-	"version": "7.6.0",
+	"version": "7.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1122,11 +1122,12 @@
 			"dev": true
 		},
 		"@bloomprotocol/qr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@bloomprotocol/qr/-/qr-2.0.0.tgz",
-			"integrity": "sha512-Rw9Nr9v0ZTIJXSTsSqWPwAAE46d6E+ci46WeLCT4wG8tk7gix/braPCpJqNR1K0Pf2441FGq7cfbUZC0EYRqGg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@bloomprotocol/qr/-/qr-2.0.1.tgz",
+			"integrity": "sha512-w0hCaPk7fJzN4q7ZWaf6/Oz8klcn76UBGrqkTXzolbLXcNx+yHcBW2ah84I5ExvjBWcYtGwLRAFKIBsdh7TRVQ==",
 			"requires": {
-				"qr.js": "0.0.0"
+				"qr.js": "0.0.0",
+				"tslib": "^1.10.0"
 			}
 		},
 		"@cnakazawa/watch": {
@@ -14651,8 +14652,7 @@
 		"tslib": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/packages/share-kit/package.json
+++ b/packages/share-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/share-kit",
-  "version": "7.6.0",
+  "version": "7.6.1",
   "main": "dist/index.js",
   "module": "dist/share-kit.esm.js",
   "typings": "dist/index.d.ts",
@@ -22,13 +22,14 @@
     "storybook": "start-storybook -p 9001"
   },
   "dependencies": {
-    "@bloomprotocol/attestations-common": "^1.0.0",
-    "@bloomprotocol/qr": "^2.0.0",
+    "@bloomprotocol/attestations-common": "^1.0.1",
+    "@bloomprotocol/qr": "^2.0.1",
     "@types/common-tags": "^1.8.0",
     "@types/extend": "^3.0.1",
     "bowser": "^2.4.0",
     "common-tags": "^1.8.0",
     "extend": "^3.0.2",
+    "tslib": "^1.10.0",
     "url": "^0.11.0"
   },
   "devDependencies": {
@@ -51,7 +52,6 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "tsdx": "^0.12.1",
-    "tslib": "^1.10.0",
     "typescript": "^3.7.4",
     "webpack": "^4.41.5"
   },

--- a/packages/verify-kit/CHANGELOG.md
+++ b/packages/verify-kit/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.1
+
+**Bug fixes**:
+
+- Include tslib in dependencies
+
 ## 2.0.0
 
 **Improvements**

--- a/packages/verify-kit/package-lock.json
+++ b/packages/verify-kit/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/verify-kit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10123,8 +10123,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tsutils": {
       "version": "3.17.1",

--- a/packages/verify-kit/package.json
+++ b/packages/verify-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/verify-kit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "module": "dist/verify-kit.esm.js",
   "typings": "dist/index.d.ts",
@@ -21,10 +21,11 @@
     "prepublishOnly": "npm run test && npm run lint"
   },
   "dependencies": {
-    "@bloomprotocol/attestations-common": "^1.0.0",
+    "@bloomprotocol/attestations-common": "^1.0.1",
     "abi-decoder": "^2.2.2",
     "ethereumjs-util": "^6.2.0",
     "js-sha3": "^0.8.0",
+    "tslib": "^1.10.0",
     "web3": "^1.2.4"
   },
   "devDependencies": {
@@ -42,7 +43,6 @@
     "ethereumjs-wallet": "^0.6.3",
     "prettier": "^1.19.1",
     "tsdx": "^0.12.1",
-    "tslib": "^1.10.0",
     "typescript": "^3.7.4"
   },
   "jest": {


### PR DESCRIPTION
## Ultimate Problem
There is a new qr package with tslib included in it's deps, and these packages should all include it as well

## Solution
- Bump to latest qr version
- Include tslib in all deps